### PR TITLE
Use alert labels for dynamic connector selection

### DIFF
--- a/alert/testdata/prom_post_request_label.json
+++ b/alert/testdata/prom_post_request_label.json
@@ -1,0 +1,37 @@
+{
+  "version": "4",
+  "groupKey": "{}:{alertname=\"high_memory_load\"}",
+  "status": "firing",
+  "receiver": "teams_proxy",
+  "groupLabels": {
+      "alertname": "high_memory_load"
+  },
+  "commonLabels": {
+      "alertname": "high_memory_load",
+      "monitor": "master",
+      "severity": "warning",
+      "msteams_endpoint": "dump"
+  },
+  "commonAnnotations": {
+      "summary": "Server High Memory usage",
+      "runbook": "https://github.com/bzon/prometheus-msteams"
+  },
+  "externalURL": "http://docker.for.mac.host.internal:9093",
+  "alerts": [
+      {
+          "labels": {
+              "alertname": "high_memory_load",
+              "instance": "instance-with-hyphen_and_underscore",
+              "job": "docker_nodes",
+              "monitor": "master",
+              "severity": "warning"
+          },
+          "annotations": {
+              "description": "10.80.40.11 reported high memory usage with 23.28%.",
+              "summary": "Server High Memory usage"
+          },
+          "startsAt": "2018-03-07T06:33:21.873077559-05:00",
+          "endsAt": "0001-01-01T00:00:00Z"
+      }
+  ]
+}

--- a/alert/testdata/prom_post_request_label.json
+++ b/alert/testdata/prom_post_request_label.json
@@ -10,7 +10,7 @@
       "alertname": "high_memory_load",
       "monitor": "master",
       "severity": "warning",
-      "msteams_endpoint": "channel_2"
+      "msteams_connector": "channel_2"
   },
   "commonAnnotations": {
       "summary": "Server High Memory usage",

--- a/alert/testdata/prom_post_request_label.json
+++ b/alert/testdata/prom_post_request_label.json
@@ -10,7 +10,7 @@
       "alertname": "high_memory_load",
       "monitor": "master",
       "severity": "warning",
-      "msteams_endpoint": "dump"
+      "msteams_endpoint": "channel_2"
   },
   "commonAnnotations": {
       "summary": "Server High Memory usage",

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -50,7 +50,7 @@ This is an example config file content in YAML format.
 
 ---
 label: msteams_endpoint
-fallback: alertmanager
+fallback: channel_1
 connectors:
 - channel_1: https://outlook.office.com/webhook/xxxx/hook/for/channel1
 - channel_2: https://outlook.office.com/webhook/xxxx/hook/for/channel2


### PR DESCRIPTION
With these changes, alerts can be routed to different connectors based on an label in the alert.
The endpoint for this is `/_by-label`.
Alerts sent to this endpoint without a label will use a fallback connector.