### PR TITLE
Use external Url for the silence link

### DIFF
--- a/examples/templates/card-with-silence-action.tmpl
+++ b/examples/templates/card-with-silence-action.tmpl
@@ -43,7 +43,7 @@
         {{- range $index, $alert := .Alerts }}
           {{- if eq $index 0}}
             "target": [
-                "http://localhost:9093/#/silences/new?filter=%7B{{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}}%22%2C%20{{ end }}{{ $key }}%3D%22{{ $value }}{{- end }}%22%7D"
+                "{{ $externalUrl }}/#/silences/new?filter=%7B{{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}}%22%2C%20{{ end }}{{ $key }}%3D%22{{ $value }}{{- end }}%22%7D"
             ]
           {{- end }}
         {{- end }}


### PR DESCRIPTION
The link for silencing an alert is hardcoded to `http://localhost:9093`. This should use the external URL value like elsewhere in the template.