### PR TITLE
Release Windows binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ deploy:
   file:
     - ./bin/prometheus-msteams-darwin-amd64
     - ./bin/prometheus-msteams-linux-amd64
+    - /.bin/prometheus-msteams-windows-amd64.exe
     - ./bin/shasum256.txt
     - ./default-message-card.tmpl
   skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ linux:
 darwin:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=$(GOARCH) $(GO) build $(LDFLAGS) -o $(BINDIR)/$(BINARY)-darwin-$(GOARCH) ./cmd/server
 
+windows:
+	CGO_ENABLED=0 GOOS=windows GOARCH=$(GOARCH) $(GO) build $(LDFLAGS) -o $(BINDIR)/$(BINARY)-windows-$(GOARCH).exe ./cmd/server
+
 docker:
 	docker build -t $(DOCKER_HUB_REPO):$(VERSION) .
 	docker tag $(DOCKER_HUB_REPO):$(VERSION) $(DOCKER_QUAY_REPO):$(VERSION)


### PR DESCRIPTION
Would be nice to have MS Teams integration on Windows as well. I've compiled it on Linux and tested the binary on Windows 2019 and Windows 2012 R2.