### PR TITLE
Add initial helm-chart github-actions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,27 @@
+name: Lint and Test Helm-Chart
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0
+        with:
+          command: lint
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        if: steps.lint.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.0.0
+        with:
+          command: install

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -8,8 +8,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
 
       - name: Run chart-testing (lint)
         id: lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        run: |
+          curl -sSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get
+          chmod 700 get_helm.sh
+          ./get_helm.sh
+          helm init --client-only
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.0.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,14 +19,9 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
-        run: |
-          curl -sSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get
-          chmod 700 get_helm.sh
-          ./get_helm.sh
-          helm init --client-only
-
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0
+        with:
+          charts_dir: chart
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/chart/prometheus-msteams/README.md
+++ b/chart/prometheus-msteams/README.md
@@ -17,7 +17,7 @@
 Clone this repository.
 
 ```bash
-helm repo add prometheus-msteams https://prometheus-msteams.github.io/helm-chart/
+helm repo add prometheus-msteams https://prometheus-msteams.github.io/prometheus-msteams/
 ```
 
 ### Prepare the Deployment configuration

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,4 +3,3 @@ remote: origin
 chart-dirs:
   - chart
 chart-repos: []
-helm-extra-args: --timeout 600

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,6 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+chart-dirs:
+  - chart
+chart-repos: []
+helm-extra-args: --timeout 600


### PR DESCRIPTION
Signed-off-by: Christian Kotzbauer <christian.kotzbauer@gmail.com>

This adds two github-actions for linting and testing on pull-requests and for publishing to github-pages. When this is merged and is working the repo on helm-hub should be updated.

Closes #149 