### PR TITLE
fix helm chart default card template

### DIFF
--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -2,4 +2,10 @@ apiVersion: v1
 appVersion: "v1.4.1"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
+home: https://github.com/prometheus-msteams/prometheus-msteams
 version: 0.5.2
+maintainers:
+  - name: bzon
+    url: https://github.com/bzon
+  - name: Knappek
+    url: https://github.com/Knappek

--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v1.4.1"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
-version: 0.5.1
+version: 0.5.2

--- a/chart/prometheus-msteams/card.tmpl
+++ b/chart/prometheus-msteams/card.tmpl
@@ -10,14 +10,18 @@
                  {{- else -}}808080{{- end -}}",
   "summary": "{{- if eq .CommonAnnotations.summary "" -}}
                   {{- if eq .CommonAnnotations.message "" -}}
-                    {{- .CommonLabels.alertname -}}
+                    {{- if eq .CommonLabels.alertname "" -}}
+                      Prometheus Alert
+                    {{- else -}}
+                      {{- .CommonLabels.alertname -}}
+                    {{- end -}}
                   {{- else -}}
                     {{- .CommonAnnotations.message -}}
                   {{- end -}}
               {{- else -}}
                   {{- .CommonAnnotations.summary -}}
               {{- end -}}",
-  "title": "Prometheus Alert ({{ .Status }})",
+  "title": "Prometheus Alert ({{ .Status | title }})",
   "sections": [ {{$externalUrl := .ExternalURL}}
   {{- range $index, $alert := .Alerts }}{{- if $index }},{{- end }}
     {

--- a/chart/prometheus-msteams/values.yaml
+++ b/chart/prometheus-msteams/values.yaml
@@ -45,12 +45,8 @@ metrics:
 connectors: []
 connectors_with_custom_templates: []
 
-
 ## Specify the custom message card template for MS teams
 # customCardTemplate: |
 #   {{ define "teams.card" }}
-#   {
-#     
-#   }
+#   {...}
 #   {{ end }}
-


### PR DESCRIPTION
Sync the [repo's default card template](https://github.com/prometheus-msteams/prometheus-msteams/blob/master/default-message-card.tmpl) with the chart's card template.

closes #154 . 