### PR TITLE
Don't include "description" in "facts"

### DIFF
--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.4.1"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
 home: https://github.com/prometheus-msteams/prometheus-msteams
-version: 0.6.0
+version: 0.6.1
 maintainers:
   - name: bzon
     url: https://github.com/bzon

--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.4.1"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
 home: https://github.com/prometheus-msteams/prometheus-msteams
-version: 0.5.2
+version: 0.6.0
 maintainers:
   - name: bzon
     url: https://github.com/bzon

--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.4.1"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
 home: https://github.com/prometheus-msteams/prometheus-msteams
-version: 0.6.1
+version: 0.6.0
 maintainers:
   - name: bzon
     url: https://github.com/bzon

--- a/chart/prometheus-msteams/card.tmpl
+++ b/chart/prometheus-msteams/card.tmpl
@@ -29,8 +29,11 @@
       "facts": [
         {{- range $key, $value := $alert.Annotations }}
         {
-          "name": "{{ $key }}",
-          "value": "{{ $value }}"
+          {{- if eq $key "description" -}}
+          {{- else -}}
+            "name": "{{ $key }}",
+            "value": "{{ $value }}"
+            {{- end -}}
         },
         {{- end -}}
         {{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}},{{ end }}

--- a/chart/prometheus-msteams/card.tmpl
+++ b/chart/prometheus-msteams/card.tmpl
@@ -29,11 +29,10 @@
       "facts": [
         {{- range $key, $value := $alert.Annotations }}
         {
-          {{- if eq $key "description" -}}
-          {{- else -}}
+          {{- if ne $key "description" -}}
             "name": "{{ $key }}",
             "value": "{{ $value }}"
-            {{- end -}}
+          {{- end -}}
         },
         {{- end -}}
         {{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}},{{ end }}

--- a/default-message-card.tmpl
+++ b/default-message-card.tmpl
@@ -29,8 +29,11 @@
       "facts": [
         {{- range $key, $value := $alert.Annotations }}
         {
-          "name": "{{ $key }}",
-          "value": "{{ $value }}"
+          {{- if eq $key "description" -}}
+          {{- else -}}
+            "name": "{{ $key }}",
+            "value": "{{ $value }}"
+            {{- end -}}
         },
         {{- end -}}
         {{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}},{{ end }}

--- a/default-message-card.tmpl
+++ b/default-message-card.tmpl
@@ -29,11 +29,10 @@
       "facts": [
         {{- range $key, $value := $alert.Annotations }}
         {
-          {{- if eq $key "description" -}}
-          {{- else -}}
+          {{- if ne $key "description" -}}
             "name": "{{ $key }}",
             "value": "{{ $value }}"
-            {{- end -}}
+          {{- end -}}
         },
         {{- end -}}
         {{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}},{{ end }}

--- a/pkg/card/templated_card_test.go
+++ b/pkg/card/templated_card_test.go
@@ -33,10 +33,7 @@ func Test_templatedCard_Convert(t *testing.T) {
 						ActivityTitle: "[10.80.40.11 reported high memory usage with 23.28%.](http://docker.for.mac.host.internal:9093)",
 						Markdown:      true,
 						Facts: []FactSection{
-							{
-								Name:  "description",
-								Value: "10.80.40.11 reported high memory usage with 23.28%.",
-							},
+							{},
 							{Name: "summary", Value: "Server High Memory usage"},
 							{Name: "alertname", Value: `high_memory_load`},
 							{Name: "instance", Value: `instance-with-hyphen_and_underscore`},
@@ -64,10 +61,7 @@ func Test_templatedCard_Convert(t *testing.T) {
 						ActivityTitle: "[10.80.40.11 reported high memory usage with 23.28%.](http://docker.for.mac.host.internal:9093)",
 						Markdown:      true,
 						Facts: []FactSection{
-							{
-								Name:  "description",
-								Value: "10.80.40.11 reported high memory usage with 23.28%.",
-							},
+							{},
 							{Name: "summary", Value: "Server High Memory usage"},
 							{Name: "alertname", Value: `high\_memory\_load`},
 							{Name: "instance", Value: `instance-with-hyphen\_and\_underscore`},
@@ -95,10 +89,7 @@ func Test_templatedCard_Convert(t *testing.T) {
 						ActivityTitle: "[10.80.40.11 reported high memory usage with 23.28%.](http://docker.for.mac.host.internal:9093)",
 						Markdown:      true,
 						Facts: []FactSection{
-							{
-								Name:  "description",
-								Value: "10.80.40.11 reported high memory usage with 23.28%.",
-							},
+							{},
 							{Name: "summary", Value: "Server High Memory usage"},
 							{Name: "alertname", Value: `high\_memory\_load`},
 							{Name: "instance", Value: `instance-with-hyphen\_and\_underscore`},

--- a/pkg/card/testdata/action-message-card.tmpl
+++ b/pkg/card/testdata/action-message-card.tmpl
@@ -25,8 +25,11 @@
       "facts": [
         {{- range $key, $value := $alert.Annotations }}
         {
-          "name": "{{ $key }}",
-          "value": "{{ $value }}"
+          {{- if eq $key "description" -}}
+          {{- else -}}
+            "name": "{{ $key }}",
+            "value": "{{ $value }}"
+            {{- end -}}
         },
         {{- end -}}
         {{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}},{{ end }}

--- a/pkg/card/testdata/action-message-card.tmpl
+++ b/pkg/card/testdata/action-message-card.tmpl
@@ -25,11 +25,10 @@
       "facts": [
         {{- range $key, $value := $alert.Annotations }}
         {
-          {{- if eq $key "description" -}}
-          {{- else -}}
+          {{- if ne $key "description" -}}
             "name": "{{ $key }}",
             "value": "{{ $value }}"
-            {{- end -}}
+          {{- end -}}
         },
         {{- end -}}
         {{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}},{{ end }}


### PR DESCRIPTION
### Stop "description" annotation from showing up in card facts 

See #156 for details.

### Changes done to the code base

* Added if statement to exclude "description" annotation to template (both chart and default).
* Incremented chart version.
* Adapted tests by removing "description" fact from expected results and adding if statement
    to the template in test data.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
