### PR TITLE
Helm Chart: Automatically rollout restart pod when configmaps change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ coverage.txt
 
 # MacOS stuff
 .DS_Store
+
+# IntellIJ
+.idea
+*.iml

--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.4.1"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
 home: https://github.com/prometheus-msteams/prometheus-msteams
-version: 0.7.0
+version: 0.7.1
 maintainers:
   - name: bzon
     url: https://github.com/bzon

--- a/chart/prometheus-msteams/templates/deployment.yaml
+++ b/chart/prometheus-msteams/templates/deployment.yaml
@@ -18,8 +18,10 @@ spec:
       labels:
         app: {{ template "app.name" . }}
         release: {{ .Release.Name }}
-    {{- if .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configMapConfig.yaml") . | sha256sum }}
+        checksum/msteams-card-templates: {{ include (print $.Template.BasePath "/configMapTemplate.yaml") . | sha256sum }}
+    {{- if .Values.podAnnotations }}
     {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}
     spec:


### PR DESCRIPTION
Currently when the config of prometheus-msteams changes only the config map is updated and the pod is not restarted. The pod is still running with the old configuration then. Proposal by helm is to set an annotation to the pod that triggers a rollout restart in this case (see https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments). Like this the new configuration will be used by the new pod.

(added some IntellIJ Idea related gitignore settings)