### PR TITLE
make extraEnvs default value in helm an empty map

### DIFF
--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.4.1"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
 home: https://github.com/prometheus-msteams/prometheus-msteams
-version: 0.7.1
+version: 0.7.2
 maintainers:
   - name: bzon
     url: https://github.com/bzon

--- a/chart/prometheus-msteams/values.yaml
+++ b/chart/prometheus-msteams/values.yaml
@@ -8,7 +8,7 @@ image:
 
 imagePullSecrets: []
 
-extraEnvs:
+extraEnvs: {}
 
 container:
   port: 2000


### PR DESCRIPTION
Otherwise helm will log:

```
coalesce.go:160: warning: skipped value for environment: Not a table.
```

when overriding this value.

See helm/helm#8283