### PR TITLE
Change ServiceMonitor `targetPort` to container's port

### DIFF
--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.4.2"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
 home: https://github.com/prometheus-msteams/prometheus-msteams
-version: 1.1.0
+version: 1.1.1
 maintainers:
   - name: bzon
     url: https://github.com/bzon

--- a/chart/prometheus-msteams/templates/servicemonitor.yaml
+++ b/chart/prometheus-msteams/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - targetPort: {{ .Values.service.port }}
+    - targetPort: {{ .Values.container.port }}
       path: /metrics
       interval: {{ .Values.metrics.serviceMonitor.scrapeInterval }}
       {{- if .Values.metrics.serviceMonitor.honorLabels }}


### PR DESCRIPTION
The `ServiceMonitor` definition states that the `targetPort` should "target the port of the Pod behind the Service"
```yaml
targetPort:
  anyOf:
  - type: integer
  - type: string
  description: Name or number of the target port of the Pod behind the Service, the port must be specified with container port property. Mutually exclusive with port.
  x-kubernetes-int-or-string: true
```