### PR TITLE
Bump alpine version to 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9.5
+FROM alpine:3.13
 
 RUN apk --no-cache add ca-certificates tini
 


### PR DESCRIPTION
Snyk reports vulnerabilities in alpine 3.9.5's openssl and musl installations.
Snyk on alpine 3.13 does not show any known vulnerabilities so far.

Vulnerability meta:
| ID | Package | Severity |
| --- | --- | --- |
| CVE-2020-1967 | openssl | high |
| CVE-2020-28928 | musl | medium |