### PR TITLE
Removing duplicated imagePullPolicy definition

### DIFF
--- a/chart/prometheus-msteams/templates/deployment.yaml
+++ b/chart/prometheus-msteams/templates/deployment.yaml
@@ -63,7 +63,6 @@ spec:
           {{- with .Values.container.additionalArgs }}
 {{ toYaml . | indent 12 }}
           {{- end}}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - name: http
             containerPort: {{ .Values.container.port }}


### PR DESCRIPTION
This is making some security scanning tools to fail (polaris) due to wrong yaml definition.

fixes #194 