### PR TITLE
Include linux/arm64 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ deploy:
   api_key: $GITHUB_OAUTH_TOKEN
   file:
     - ./bin/prometheus-msteams-darwin-amd64
+    - ./bin/prometheus-msteams-linux-arm64
     - ./bin/prometheus-msteams-linux-amd64
     - ./bin/prometheus-msteams-windows-amd64.exe
     - ./bin/shasum256.txt


### PR DESCRIPTION
Hi,

I'm not as familiar with golang best practices for Makefiles, and would open to making additional changes if needed.

For context, I'm looking to bring up an instance of prometheus-msteams on one of Amazon's ARM instances. While I am able to compile the binary locally, being able to download each release direct from GitHub would streamline the process.

I was able to build linux/arm64 binaries with golang 1.13.7 (the version used for Travis), and was able to build windows/arm64 and darwin/arm64 with more recent versions of golang.