### PR TITLE
added validation for incoming message (prevents panic)

### DIFF
--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -121,6 +121,13 @@ func handleRoute(c echo.Context, s service.Service, logger log.Logger) error {
 		return c.String(500, err.Error())
 	}
 
+	if wm.Data == nil || wm.Version == "" || wm.GroupKey == "" {
+		err = fmt.Errorf("validation of webhook message failed. Required fields are missing")
+		logger.Log("err", err)
+		span.SetStatus(trace.Status{Code: 500, Message: err.Error()})
+		return c.String(500, err.Error())
+	}
+
 	prs, err := s.Post(ctx, wm)
 	if err != nil {
 		logger.Log("err", err)

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -122,7 +122,7 @@ func handleRoute(c echo.Context, s service.Service, logger log.Logger) error {
 	}
 
 	if wm.Data == nil || wm.Version == "" || wm.GroupKey == "" {
-		err = fmt.Errorf("validation of webhook message failed. Required fields are missing")
+		err = fmt.Errorf("the webhook message does not seem to be a valid Prometheus Alertmanager webhook. More information see https://prometheus.io/docs/alerting/latest/configuration/#webhook_config")
 		logger.Log("err", err)
 		span.SetStatus(trace.Status{Code: 500, Message: err.Error()})
 		return c.String(500, err.Error())


### PR DESCRIPTION
Hi,

the problem with of the panic is caused by the embedded pointer to *template.Data in webhook.Message (alertmanager)
https://github.com/prometheus/alertmanager/blob/v0.20.0/notify/webhook/webhook.go#L69

if template.Data is nil, all access to fields of template.Data will cause a panic. For example here:
https://github.com/prometheus-msteams/prometheus-msteams/blob/2c782049ccc0d4ea41338625f71ee279e6ffe004/pkg/card/templated_card.go#L60

Somewhere the application revers from panic. So maybe you want to keep it like it is?

fixes #209