### PR TITLE
Fix Alertmanager URL scheme with filter

### DIFF
--- a/examples/templates/card-grafana-inspired.tmpl
+++ b/examples/templates/card-grafana-inspired.tmpl
@@ -177,7 +177,7 @@ used if common `template` annotation is not `group`.
             "targets": [
               {
                 "os": "default", 
-                "uri": "{{ .ExternalURL }}/#/alerts/silenced=true&inhibited=true&active=true?filter=%7B{{$c := counter}}{{ range $key, $value := .CommonLabels }}{{if call $c}}%22%2C%20{{ end }}{{ $key }}%3D%22{{ $value }}{{- end }}%22%7D"
+                "uri": "{{ .ExternalURL }}/#?alerts/silenced=true&inhibited=true&active=true&filter=%7B{{$c := counter}}{{ range $key, $value := .CommonLabels }}{{if call $c}}%22%2C%20{{ end }}{{ $key }}%3D%22{{ $value }}{{- end }}%22%7D"
               }
             ]
           }
@@ -266,7 +266,7 @@ used if common `template` annotation is not `group`.
                   "targets": [
                     {
                       "os": "default", 
-                      "uri": "{{ $externalUrl }}/#/alerts/silenced=true&inhibited=true&active=true?filter=%7B{{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}}%22%2C%20{{ end }}{{ $key }}%3D%22{{ $value }}{{- end }}%22%7D"
+                      "uri": "{{ $externalUrl }}/#?alerts/silenced=true&inhibited=true&active=true&filter=%7B{{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}}%22%2C%20{{ end }}{{ $key }}%3D%22{{ $value }}{{- end }}%22%7D"
                     }
                   ]
                 }


### PR DESCRIPTION
As I also ran into the same issue described in #176, I wanted to contribute the fix.

This PR fixes the Alertmanger URL scheme in the example to enable correct filtering of alerts. The current URL configuration in the example leads to a not found page.