### PR TITLE
specify namespace for all resources

### DIFF
--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.5.0"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
 home: https://github.com/prometheus-msteams/prometheus-msteams
-version: 1.3.0
+version: 1.4.0
 maintainers:
   - name: bzon
     url: https://github.com/bzon

--- a/chart/prometheus-msteams/templates/configMapConfig.yaml
+++ b/chart/prometheus-msteams/templates/configMapConfig.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "app.name" . }}-config
+  namespace: {{ .Release.Namespace }}
 data:
   connectors.yaml: |
     {{- with $.Values.connectors }}

--- a/chart/prometheus-msteams/templates/configMapTemplate.yaml
+++ b/chart/prometheus-msteams/templates/configMapTemplate.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
  name: {{ template "app.name" . }}-card-template
+ namespace: {{ .Release.Namespace }}
 binaryData:
   card.tmpl: |-
 {{- if .Values.customCardTemplate }}

--- a/chart/prometheus-msteams/templates/deployment.yaml
+++ b/chart/prometheus-msteams/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "app.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "app.name" . }}
     chart: {{ template "app.chart" . }}

--- a/chart/prometheus-msteams/templates/service.yaml
+++ b/chart/prometheus-msteams/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "app.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "app.name" . }}
     chart: {{ template "app.chart" . }}

--- a/chart/prometheus-msteams/templates/servicemonitor.yaml
+++ b/chart/prometheus-msteams/templates/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "app.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{ else }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
     app: {{ template "app.name" . }}


### PR DESCRIPTION
This allows `helm template` users to specify `--namespace something` while generating YAML files. See https://github.com/helm/helm/issues/3553 for details and possible (other) workarounds.

Note that without specifying `--namespace` while calling `helm template`, `{{ .Release.Namespace }}` defaults to `default` which might contradict what changed in https://github.com/prometheus-msteams/prometheus-msteams/issues/25.