### PR TITLE
Add tzdata package to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-RUN apk --no-cache add ca-certificates tini
+RUN apk --no-cache add ca-certificates tini tzdata
 
 LABEL description="A lightweight Go Web Server that accepts POST alert message from Prometheus Alertmanager and sends it to Microsoft Teams Channels using an incoming webhook url."
 


### PR DESCRIPTION
By default, Alpine Docker images don't include time zone data (see e.g. [here](https://www.stevejgordon.co.uk/timezonenotfoundexception-in-alpine-based-docker-images)). This results in e.g. the Sprig [`dateInZone`](http://masterminds.github.io/sprig/date.html) function to silently fall back to UTC because it can't look up the requested time zone on the system.

For example, the following call:

```gotmpl
{{- with index .Alerts 0 }}
  {{ dateInZone "2006-01-02 15:04:05.00 MST" .StartsAt "CET" }}
{{- end }}
```

would fail to convert the start time of the alert to CET and just leave it in UTC.

Installing the [`tzdata`](https://pkgs.alpinelinux.org/package/edge/main/x86/tzdata) package in the Dockerfile fixes this problem.

The package adds just about 1.2 MB to the size of the Docker image.