### PR TITLE
Ability to render environments variables in card template.

### DIFF
--- a/pkg/card/templated_card.go
+++ b/pkg/card/templated_card.go
@@ -158,8 +158,8 @@ func envToMap() map[string]string {
 	envMap := make(map[string]string)
 
 	for _, v := range os.Environ() {
-		split_v := strings.Split(v, "=")
-		envMap[split_v[0]] = strings.Join(split_v[1:], "=")
+		splitV := strings.Split(v, "=")
+		envMap[splitV[0]] = strings.Join(splitV[1:], "=")
 	}
 
 	return envMap

--- a/pkg/card/templated_card_test.go
+++ b/pkg/card/templated_card_test.go
@@ -2,6 +2,7 @@ package card
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -109,7 +110,18 @@ func Test_templatedCard_Convert(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "card with .Env",
+			promAlertFile: "./testdata/prom_post_request.json",
+			templateFile:  "./testdata/env-message-card.tmpl",
+			want: Office365ConnectorCard{
+				Type:  "MessageCard",
+				Title: "EXAMPLE",
+			},
+		},
 	}
+
+	os.Setenv("EXAMPLE", "EXAMPLE")
 
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/card/testdata/env-message-card.tmpl
+++ b/pkg/card/testdata/env-message-card.tmpl
@@ -1,0 +1,6 @@
+{{ define "teams.card" }}
+{
+  "@type": "MessageCard",
+  "title": "{{ .Env.EXAMPLE }}"
+}
+{{ end }}


### PR DESCRIPTION
In our project we have several clusters where we install prometheus-msteams helm chart. We distinguish clusters in notifications' titles. We do not want to put to values whole card template for each cluster, thus the change.

It allows to render environment variables in card tmpl like this {{ .Env.NameOfEnvVariable}}.  