### PR TITLE
Move golangci-lint from Travis to GH Actions

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,23 @@
+name: golangci-lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  golangci:
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.45.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
     - depguard
     - dogsled
     - dupl
+    - exportloopref
     - errcheck
     - funlen
     - gochecknoinits
@@ -13,17 +14,15 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - nakedret
+    - revive
     - rowserrcheck
-    - scopelint
     - staticcheck
     - structcheck
     - stylecheck
@@ -36,7 +35,7 @@ linters:
 issues:
   exclude-rules:
     - linters:
-       - golint
+       - revive
       text: "don't use ALL_CAPS in Go names"
     - linters:
        - stylecheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,10 @@ services:
   - docker
 
 install:
-  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
   - make dep
 
 script:
   # Code coverage and testing
-  - make lint
   - make coverage
   - bash <(curl -s https://codecov.io/bash)
   - bash ./travis.sh || travis_terminate 1

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ create_bin_dir:
 
 github_release:
 	github-release release -u bzon -r prometheus-msteams -t $(VERSION) -n $(VERSION)
-	
-linux: 
+
+linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) $(GO) build $(LDFLAGS) -o $(BINDIR)/$(BINARY)-linux-$(GOARCH) ./cmd/server
 
 darwin:


### PR DESCRIPTION
Hi @bzon, @Knappek,

This PR moves [golangci-lint](https://github.com/golangci/golangci-lint) from TravisCI to a native GHActions app, and also update it to the latest version.

NOTE: I´ve found a committed binary file too, which I am removing, as it seems to be a mistake for me. Let me know if I oversaw something. 