### PR TITLE
Implementing webhook-url from secret in connectorsWithCustomTemplates

### DIFF
--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.5.1"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
 home: https://github.com/prometheus-msteams/prometheus-msteams
-version: 1.3.2
+version: 1.4.0
 maintainers:
   - name: bzon
     url: https://github.com/bzon

--- a/chart/prometheus-msteams/README.md
+++ b/chart/prometheus-msteams/README.md
@@ -94,7 +94,8 @@ To define a custom message template per MS Teams channel you can use the followi
 
 ```yaml
 connectorsWithCustomTemplates:
-  - request_path: /alert2
+  - name: custom_alert_channel
+    request_path: /alert2
     webhook_url: https://outlook.office.com/webhook/xxxx/xxxx
     escape_underscores: true
 ```
@@ -113,8 +114,12 @@ Otherwise you can also set the value by specifying the template data directly vi
 
 ```yaml
 connectorsWithCustomTemplates:
-  - request_path: /alert2
+  - name: custom_alert_channel
+    request_path: /alert2
     webhook_url: https://outlook.office.com/webhook/xxxx/xxxx
+    webhook_secret: 
+      name: msteams-webhook
+      key: url
     escape_underscores: true
     template_file: |
       {{ define "teams.card" }}

--- a/chart/prometheus-msteams/templates/configMapConfig.yaml
+++ b/chart/prometheus-msteams/templates/configMapConfig.yaml
@@ -13,7 +13,11 @@ data:
 {{- range $index, $connectorWithCustomTemplate := .Values.connectorsWithCustomTemplates }}
       - request_path: {{ $connectorWithCustomTemplate.request_path }}
         template_file: /etc/template/custom_card_{{ $index }}.tmpl
-        webhook_url: {{ $connectorWithCustomTemplate.webhook_url }}
+        {{- if $connectorWithCustomTemplate.webhook_url }}
+        webhook_url: {{ $connectorWithCustomTemplate.name | upper }}_SECRET_VAR
+        {{- else if and $connectorWithCustomTemplate.webhook_secret.name $connectorWithCustomTemplate.webhook_secret.key }}
+        webhook_url: {{ $connectorWithCustomTemplate.name | upper }}_SECRET_VAR
+        {{- end}}
 {{- if hasKey $connectorWithCustomTemplate "escape_underscores" }}
         escape_underscores: {{ $connectorWithCustomTemplate.escape_underscores }}
 {{- end }}

--- a/chart/prometheus-msteams/templates/configMapConfig.yaml
+++ b/chart/prometheus-msteams/templates/configMapConfig.yaml
@@ -12,7 +12,11 @@ data:
     connectors_with_custom_templates:
 {{- range $index, $connectorWithCustomTemplate := .Values.connectorsWithCustomTemplates }}
       - request_path: {{ $connectorWithCustomTemplate.request_path }}
+        {{- if $connectorWithCustomTemplate.template_file }}
         template_file: /etc/template/custom_card_{{ $index }}.tmpl
+        {{- else }}
+        template_file: /etc/template/card.tmpl
+        {{- end}}
         {{- if $connectorWithCustomTemplate.webhook_url }}
         webhook_url: {{ $connectorWithCustomTemplate.name | upper }}_SECRET_VAR
         {{- else if and $connectorWithCustomTemplate.webhook_secret.name $connectorWithCustomTemplate.webhook_secret.key }}

--- a/chart/prometheus-msteams/templates/configMapConfig.yaml
+++ b/chart/prometheus-msteams/templates/configMapConfig.yaml
@@ -18,9 +18,9 @@ data:
         template_file: /etc/template/card.tmpl
         {{- end}}
         {{- if $connectorWithCustomTemplate.webhook_url }}
-        webhook_url: {{ $connectorWithCustomTemplate.name | upper }}_SECRET_VAR
+        webhook_secret: {{ $connectorWithCustomTemplate.name | upper }}_SECRET_VAR
         {{- else if and $connectorWithCustomTemplate.webhook_secret.name $connectorWithCustomTemplate.webhook_secret.key }}
-        webhook_url: {{ $connectorWithCustomTemplate.name | upper }}_SECRET_VAR
+        webhook_secret: {{ $connectorWithCustomTemplate.name | upper }}_SECRET_VAR
         {{- end}}
 {{- if hasKey $connectorWithCustomTemplate "escape_underscores" }}
         escape_underscores: {{ $connectorWithCustomTemplate.escape_underscores }}

--- a/chart/prometheus-msteams/templates/deployment.yaml
+++ b/chart/prometheus-msteams/templates/deployment.yaml
@@ -55,6 +55,21 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- range $index, $connectorWithCustomTemplate := .Values.connectorsWithCustomTemplates }}
+              {{- if $connectorWithCustomTemplate.webhook_url }}
+            - name: {{ $connectorWithCustomTemplate.name | upper }}_SECRET_VAR
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "app.name" $ }}-secret
+                  key: {{ $connectorWithCustomTemplate.name | upper }}_SECRET_VAR
+              {{- else if $connectorWithCustomTemplate.webhook_secret }}
+            - name: {{ $connectorWithCustomTemplate.name | upper }}_SECRET_VAR
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $connectorWithCustomTemplate.webhook_secret.name }}
+                  key: {{ $connectorWithCustomTemplate.webhook_secret.key }}
+              {{- end}}
+            {{- end}}
           {{- if .Values.envFrom }}
           envFrom:
             {{- toYaml .Values.envFrom | nindent 12 }}

--- a/chart/prometheus-msteams/templates/secret.yaml
+++ b/chart/prometheus-msteams/templates/secret.yaml
@@ -1,0 +1,25 @@
+{{- $secret := false}}
+{{- range $index, $connectorWithCustomTemplate := .Values.connectorsWithCustomTemplates }}
+{{- if $connectorWithCustomTemplate.webhook_url }}
+{{- $secret = true}}
+{{- end}}
+{{- end}}
+
+{{- if $secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "app.name" . }}-secret
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  {{- range $index, $connectorWithCustomTemplate := .Values.connectorsWithCustomTemplates }}
+    {{- if $connectorWithCustomTemplate.webhook_url }}
+  {{ $connectorWithCustomTemplate.name | upper }}_SECRET_VAR: {{ $connectorWithCustomTemplate.webhook_url | b64enc}}
+    {{- end}}
+  {{- end}}
+{{- end}}

--- a/chart/prometheus-msteams/values.yaml
+++ b/chart/prometheus-msteams/values.yaml
@@ -74,12 +74,16 @@ connectors: []
 
 # ref: https://github.com/prometheus-msteams/prometheus-msteams#customise-messages-per-ms-teams-channel
 connectorsWithCustomTemplates: []
-# - request_path: /alert2
+# - name: <name>
+#   request_path: /alert2
 #   template_file: |
 #     {{ define "teams.card" }}
 #     {...}
 #     {{ end }}
-#   webhook_url: <webhook>
+#   webhook_url: <webhook_url>
+#   webhook_secret: 
+#     name: <secret_name>
+#     key: <secret_key>
 #   escape_underscores: true
 
 # Env from existing secrets or configmaps (in same namespace), will passed through to contains 'envFrom'

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -277,11 +277,15 @@ func main() { //nolint: funlen
 		if len(c.WebhookURL) == 0 {
 			logger.Log(
 				"err",
-				fmt.Sprintf("The webhook_url is required for request_path '%s'", c.RequestPath),
+				fmt.Sprintf("The webhook_url or webhook_secret is required for request_path '%s'", c.RequestPath),
 			)
 			os.Exit(1)
 		}
-		err := validateWebhook(c.WebhookURL)
+		logger.Log(
+			"debug",
+			fmt.Sprintf("c.WebhookSecret '%s'", os.Getenv(c.WebhookURL)),
+		) 
+		err := validateWebhook(os.Getenv(c.WebhookURL))
 		if *validateWebhookURL && err != nil {
 			logger.Log("err", err)
 			os.Exit(1)
@@ -314,7 +318,7 @@ func main() { //nolint: funlen
 
 		var r transport.Route
 		r.RequestPath = c.RequestPath
-		r.Service = service.NewSimpleService(converter, httpClient, c.WebhookURL)
+		r.Service = service.NewSimpleService(converter, httpClient, os.Getenv(c.WebhookURL))
 		r.Service = service.NewLoggingService(logger, r.Service)
 		routes = append(routes, r)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -281,10 +281,6 @@ func main() { //nolint: funlen
 			)
 			os.Exit(1)
 		}
-		logger.Log(
-			"debug",
-			fmt.Sprintf("c.WebhookSecret '%s'", os.Getenv(c.WebhookURL)),
-		) 
 		err := validateWebhook(os.Getenv(c.WebhookURL))
 		if *validateWebhookURL && err != nil {
 			logger.Log("err", err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -288,8 +288,6 @@ func main() { //nolint: funlen
 			webhookURL = os.Getenv(c.WebhookSecret)
 		}
 
-		logger.Log("debug", webhookURL)
-
 		err := validateWebhook(webhookURL)
 		if *validateWebhookURL && err != nil {
 			logger.Log("err", err)


### PR DESCRIPTION
Hello, 

This is bad practice to set sensible info in k8s manifests. 
Since that had to implement ability to:
1. Set webhook_url in connectorsWithCustomTemplates values.yaml directly -> create Secret -> Inject webhook-url in container as ENV VAR -> In connectors.yaml provide ENV variable name instead of url. 
2. Provide external secret name in webhook_secret .name and key in webhook_secret.key -> Inject webhook-url in container as ENV VAR -> In connectors.yaml provide ENV variable name instead of url. 

Additionally, implemented support of getting url from ENV VAR for application:
1. Introduced kv webhook_secret in connectors_with_custom_templates in connectors.yaml. 
2. Added support of both webhook_url and webhook_secret for main app. 

Helm Logic:
- If webhook_url set in values.yaml, webhook_url is used. 
- If webhook_secret set in values.yaml, webhook_secret is used.
- If webhook_url and webhook_secret are set in values.yaml, webhook_url is used.

Application Logic:
- If webhook_url is missing and webhook_secret is missing -> error. 
- If webhook_url is set, webhook_url is used as webhook url. 
- If webhook_secret is set, ENV VAR webhook_secret value is used as webhook url. 
- If webhook_url  and webhook_secret are set, webhook_url is used as webhook url. 

If validation is set to TRUE, only url matching logic above will be validated. 

Readme for Helm is updated (do not see use case to update main doc). 

* Additionaly fixed issue in Helm, when missing kv custom_template in connectorsWithCustomTemplates was resulting in error instead of logic described in Readme (default tmpl should be used). 

Tested with provided tests in package. 
Tested in minikube. 

Fixing: #244

