### PR TITLE
Support authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,36 @@ route:
 
 receivers:
 - name: 'prometheus-msteams'
-  webhook_configs: 
+  webhook_configs:
   - send_resolved: true
     url: 'http://localhost:2000/_dynamicwebhook/outlook.office.com/webhook/xxx' # the prometheus-msteams proxy + "/_dynamicwebhook/" + webhook url (without prefix "https://")
     # new created webhooks have a different format: https://yourtenant.webhook.office.com/webhookb2/xxx...
 ```
+
+Alternatively you can also use the webhook as a means of authorization:
+
+```yaml
+route:
+  group_by: ['alertname']
+  group_interval: 30s
+  repeat_interval: 30s
+  group_wait: 30s
+  receiver: 'prometheus-msteams'
+
+receivers:
+- name: 'prometheus-msteams'
+  webhook_configs:
+  - send_resolved: true
+    http_Config:
+      authorization:
+        type: 'webhook'
+        credentials: 'outlook.office.com/webhook/xxx' # webhook url (without prefix "https://")
+        # new created webhooks have a different format: https://yourtenant.webhook.office.com/webhookb2/xxx...
+    url: 'http://localhost:2000/_dynamicwebhook/' # the prometheus-msteams proxy + "/_dynamicwebhook/"
+```
+
+This provides the added benefit that alertmanager will treat the Incoming
+Webhook as a credential and hides it from view in the Web UI.
 
 > If you don't have Prometheus running yet and you wan't to try how this works,  
 > try [stefanprodan's](https://github.com/stefanprodan) [Prometheus in Docker](https://github.com/stefanprodan/dockprom) to help you install a local Prometheus setup quickly in a single machine.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -232,27 +232,18 @@ func main() { //nolint: funlen
 		)
 	}
 
-	const bearerType = "webhook"
-
 	{ // dynamic uri handler: webhook uri is retrieved from request.URL
 		var r transport.DynamicRoute
 		r.RequestPath = "/_dynamicwebhook/*"
 		r.ServiceGenerator = func(c echo.Context) (service.Service, error) {
-			path := c.Request().URL.Path
-			path = strings.TrimPrefix(path, "/_dynamicwebhook/")
-			var webhook string
-			if len(path) > 0 {
-				webhook = fmt.Sprintf("https://%s", path)
-			} else {
-				authHeader := c.Request().Header.Get("Authorization")
-				if !strings.HasPrefix(authHeader, bearerType) {
-					return nil, fmt.Errorf("invalid bearer on authorization")
-				}
-				path := strings.TrimPrefix(authHeader, fmt.Sprintf("%s ", bearerType))
-				webhook = fmt.Sprintf("https://%s", path)
+			webhook, err := extractWebhookFromRequest(c.Request(), "/_dynamicwebhook/")
+			if err != nil {
+				err = errors.Wrapf(err, "webhook extraction failed for /_dynamicwebhook/")
+				logger.Log("err", err)
+				return nil, err
 			}
 
-			err := validateWebhook(webhook)
+			err = validateWebhook(webhook)
 			if *validateWebhookURL && err != nil {
 				err = errors.Wrapf(err, "webhook validation failed for /_dynamicwebhook/")
 				logger.Log("err", err)
@@ -479,4 +470,25 @@ func checkDuplicateRequestPath(routes []transport.Route) error {
 		added[r.RequestPath] = true
 	}
 	return nil
+}
+
+const bearerType = "webhook"
+
+func extractWebhookFromRequest(request *http.Request, requestPathPrefix string) (string, error) {
+	path := request.URL.Path
+	path = strings.TrimPrefix(path, requestPathPrefix)
+	if path != "" {
+		return fmt.Sprintf("https://%s", path), nil
+	}
+
+	authHeader := request.Header.Get("Authorization")
+	if authHeader == "" {
+		return "", fmt.Errorf("neither webhook url nor bearer authorization present")
+	}
+
+	if !strings.HasPrefix(authHeader, bearerType) {
+		return "", fmt.Errorf("invalid bearer on authorization")
+	}
+	path = strings.TrimPrefix(authHeader, fmt.Sprintf("%s ", bearerType))
+	return fmt.Sprintf("https://%s", path), nil
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
 	_ "net/http/pprof"
 	"testing"
 )
@@ -28,4 +30,73 @@ func Test_validateWebhook(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_extractWebhookFromRequest(t *testing.T) {
+	oldStyleWebhook := "outlook.office.com/webhook/1e21eb6d-60f4-432f-9428-82cf86ec55a3@b12d4011-2ea0-4377-a99b-35c565546afd/IncomingWebhook/091d20cd2a594db0b2d7ed2937d7bd6d/91f7b1cc-96d0-4612-bedd-8b820c869464"
+	newStyleWebhook := "example.webhook.office.com/webhookb2/5c51ab94-86c0-4ba3-a66c-c2ad73acc531@e3ebcd52-aa57-25e8-a214-94fb325450f4/IncomingWebhook/9f226e3c36fb47249f14d4dab2d5b845/92bac26e-62c5-427f-ac91-e51a268f94ca"
+	tests := []struct {
+		name          string
+		request       *http.Request
+		webhookResult string
+		wantErr       bool
+	}{
+		{
+			name:          "standard oldstyle webhook",
+			request:       newDummyRequest(fmt.Sprintf("/_dynamicwebhook/%s", oldStyleWebhook), ""),
+			webhookResult: fmt.Sprintf("https://%s", oldStyleWebhook),
+			wantErr:       false,
+		},
+		{
+			name:          "standard newstyle webhook",
+			request:       newDummyRequest(fmt.Sprintf("/_dynamicwebhook/%s", newStyleWebhook), ""),
+			webhookResult: fmt.Sprintf("https://%s", newStyleWebhook),
+			wantErr:       false,
+		},
+		{
+			name:          "auth header oldstyle webhook",
+			request:       newDummyRequest("/_dynamicwebhook/", fmt.Sprintf("webhook %s", oldStyleWebhook)),
+			webhookResult: fmt.Sprintf("https://%s", oldStyleWebhook),
+			wantErr:       false,
+		},
+		{
+			name:          "auth header newstyle webhook",
+			request:       newDummyRequest("/_dynamicwebhook/", fmt.Sprintf("webhook %s", newStyleWebhook)),
+			webhookResult: fmt.Sprintf("https://%s", newStyleWebhook),
+			wantErr:       false,
+		},
+		{
+			name:    "invalid bearer",
+			request: newDummyRequest("/_dynamicwebhook/", fmt.Sprintf("invalid-bearer %s", newStyleWebhook)),
+			wantErr: true,
+		},
+		{
+			name:    "missing webhook and header",
+			request: newDummyRequest("/_dynamicwebhook/", ""),
+			wantErr: true,
+		},
+	}
+	prefix := "/_dynamicwebhook/"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webhook, err := extractWebhookFromRequest(tt.request, prefix)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractWebhookFromRequest() error = %v, wantErr %v", err, tt.wantErr)
+			} else if tt.webhookResult != webhook {
+				t.Errorf("extractWebhookFromRequest() webhook (\"%s\") does not match expected webhook (\"%s\")", webhook, tt.webhookResult)
+			}
+		})
+	}
+}
+
+func newDummyRequest(urlPath, authHeader string) *http.Request {
+	url := fmt.Sprintf("http://localhost:2000%s", urlPath)
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		panic(err)
+	}
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	return req
 }


### PR DESCRIPTION
This PR adds functionality to the `/_dynamicwebhook/` endpoint.

Currently the endpoint requires specifying the "Incoming Webhook" URL for MS Teams as part of the URL path.
The `receivers[].webhookConfigs[].url` is not considered a "secret"/"credential" field by Alertmanager in the same way as for example `receivers[].slackConfigs[].api_url` is. That means it won't be hidden from the config in the Web UI.

In order to support handling the Incoming Webhook URL like a secret credential we can rely on the `http_config` instead.
This PR adds support for specifying the Incoming Webhook URL in the `Authorization` header, with a bearer type of `webhook`.
Alertmanager will treat this as a credential and hide it from the Web UI.