### PR TITLE
Add missing backslash to helm upgrade command

### DIFF
--- a/chart/prometheus-msteams/README.md
+++ b/chart/prometheus-msteams/README.md
@@ -63,7 +63,7 @@ See [Helm Configuration](#helm-configuration) and [App Configuration](https://gi
 
 ```bash
 helm upgrade --install prometheus-msteams \
-  --namespace default -f config.yaml
+  --namespace default -f config.yaml \
   prometheus-msteams/prometheus-msteams
 ```
 


### PR DESCRIPTION
Or else the helm command will fail with:

```txt
Error: "helm upgrade" requires 2 arguments

Usage:  helm upgrade [RELEASE] [CHART] [flags]
no such file or directory: prometheus-msteams/prometheus-msteams
```