### PR TITLE
Use go 1.18 and latest golangci

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -13,11 +13,9 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.49
           args: --timeout=2m30s


### PR DESCRIPTION
Go 1.18 is required in direct dependency [github.com/prometheus/alertmanager](https://github.com/prometheus/alertmanager/blob/2888649b473970400c0bd375fdd563486dc80481/go.mod#L1-L3) and indirect dependency [github.com/cenkalti/backoff/v4](https://github.com/cenkalti/backoff/blob/a04a6fe64ffb0e3fd0816460529d300be5f252df/go.mod#L1-L3).

> module github.com/prometheus/alertmanager
go 1.18

> module github.com/cenkalti/backoff/v4
go 1.18

Related to
#298 #301 #310 