### PR TITLE
ci: skip helm chart upload if it already exists

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -25,3 +25,4 @@ jobs:
           charts_dir: chart
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: true


### PR DESCRIPTION
Chart releaser action is failing since last release on every commit to master.
Don't know why. Maybe ignoring the issue is the way 🤷🏽 