### PR TITLE
fix(helm): changing envFrom type

### DIFF
--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.5.2"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
 home: https://github.com/prometheus-msteams/prometheus-msteams
-version: 1.3.4
+version: 1.3.5
 maintainers:
   - name: bzon
     url: https://github.com/bzon

--- a/chart/prometheus-msteams/values.yaml
+++ b/chart/prometheus-msteams/values.yaml
@@ -83,7 +83,7 @@ connectorsWithCustomTemplates: []
 #   escape_underscores: true
 
 # Env from existing secrets or configmaps (in same namespace), will passed through to contains 'envFrom'
-envFrom: {}
+envFrom: []
 # envFrom:
 #   - secretRef:
 #       name: my-prometheus-msteams-env-secret


### PR DESCRIPTION
This really small fix adapts the type of `envFrom` in the helms `values.yaml`.
`envFrom` needs to be an array, as defined in the container spec, and not an object:
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core

Otherwise it will generate a warning - it seems only when you include the chart as an external dependency:

```bash
$ helm upgrade prom-msteams . --install --create-namespace --namespace observability -f values-overwrite.yaml
Release "prom-msteams" does not exist. Installing it now.

coalesce.go:220: warning: cannot overwrite table with non table for helm-template.prometheus-msteams.envFrom (map[])

NAME: prom-msteams
LAST DEPLOYED: Fri Aug 18 09:18:00 2023
NAMESPACE: observability
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

My setup to reproduce:


<details>
  <summary>Chart.yaml</summary>

```yaml
apiVersion: v2
name: helm-template
description: A Helm chart for Kubernetes

type: application

version: 0.1.0

appVersion: "1.16.0"

dependencies:
  - name: prometheus-msteams
    # https://artifacthub.io/packages/helm/prometheus-msteams/prometheus-msteams
    version: 1.3.4
    repository: https://prometheus-msteams.github.io/prometheus-msteams/
```

</details>

<details>
  <summary>values-overwrite.yaml</summary>

```yaml
prometheus-msteams:
  envFrom:
  - secretRef:
      name: prometheus-msteams-auth
```

</details>