### PR TITLE
Force Content-Type to JSON for compatibility

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -83,6 +83,7 @@ func (s simpleService) post(ctx context.Context, c card.Office365ConnectorCard, 
 		return pr, err
 	}
 
+        req.Header.Set("Content-Type", "application/json")
 	resp, err := s.client.Do(req)
 	if err != nil {
 		err = fmt.Errorf("http client failed: %w", err)


### PR DESCRIPTION
Force Content-Type header to JSON to resolve error:

>  {\"error\":{\"code\":\"InvalidRequestContent\",\"message\":\"The input body for trigger 'manual' of type 'Request' must be of type JSON, but was of type 'application/octet-stream'.\"}}