### PR TITLE
Support new office connector url

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ __OPTION 1:__ Run using docker.
 ```bash
 docker run -d -p 2000:2000 \
     --name="promteams" \
-    -e TEAMS_INCOMING_WEBHOOK_URL="https://outlook.office.com/webhook/xxx" \
+    -e TEAMS_INCOMING_WEBHOOK_URL="https://example.webhook.office.com/webhookb2/xxx" \
     -e TEAMS_REQUEST_URI=alertmanager \
     quay.io/prometheusmsteams/prometheus-msteams
 ```
@@ -67,7 +67,7 @@ Download the binary for your platform and the default card template from [RELEAS
 
 ```bash
 ./prometheus-msteams -teams-request-uri alertmanager \
-  -teams-incoming-webhook-url "https://outlook.office.com/webhook/xxx"
+  -teams-incoming-webhook-url "https://example.webhook.office.com/webhookb2/xxx"
 ```
 
 __OPTION 3:__ If you are going to deploy this in a **Kubernetes cluster**, checkout the [Kubernetes Deployment Guide](#kubernetes-deployment).
@@ -98,7 +98,7 @@ receivers:
 The dynamic webhook handler allows you to pass the webhook url to prometheus-msteams proxy directly from alertmanager.
 
 By default the passed URL is not validated. If validation is needed, pass flag `-validate-webhook-url` to prometheus-msteams on start.
-A valid url starts with `outlook.office.com/webhook/` or matches the regular expression `^[a-z0-9]+\.webhook\.office\.com/webhookb2/[a-z0-9\-]+@[a-z0-9\-]+/IncomingWebhook/[a-z0-9]+/[a-z0-9\-]+$`.
+A valid url matches the regular expression `^[a-z0-9]+\.webhook\.office\.com/webhookb2/[a-z0-9\-]+@[a-z0-9\-]+/IncomingWebhook/[a-z0-9]+/[a-z0-9\-]+(/[a-zA-Z0-9\-]+)?$`.
 
 ```yaml
 route:
@@ -112,8 +112,7 @@ receivers:
 - name: 'prometheus-msteams'
   webhook_configs:
   - send_resolved: true
-    url: 'http://localhost:2000/_dynamicwebhook/outlook.office.com/webhook/xxx' # the prometheus-msteams proxy + "/_dynamicwebhook/" + webhook url (without prefix "https://")
-    # new created webhooks have a different format: https://yourtenant.webhook.office.com/webhookb2/xxx...
+    url: 'http://localhost:2000/_dynamicwebhook/example.webhook.office.com/webhookb2/xxx' # the prometheus-msteams proxy + "/_dynamicwebhook/" + webhook url (without prefix "https://")
 ```
 
 Alternatively you can also use the webhook as a means of authorization:
@@ -133,8 +132,7 @@ receivers:
     http_Config:
       authorization:
         type: 'webhook'
-        credentials: 'outlook.office.com/webhook/xxx' # webhook url (without prefix "https://")
-        # new created webhooks have a different format: https://yourtenant.webhook.office.com/webhookb2/xxx...
+        credentials: 'example.webhook.office.com/webhookb2/xxx' # webhook url (without prefix "https://")
     url: 'http://localhost:2000/_dynamicwebhook/' # the prometheus-msteams proxy + "/_dynamicwebhook/"
 ```
 
@@ -206,8 +204,8 @@ Create a yaml file with the following format.
 
 ```yaml
 connectors:
-- high_priority_channel: "https://outlook.office.com/webhook/xxxx/aaa/bbb"
-- low_priority_channel: "https://outlook.office.com/webhook/xxxx/aaa/ccc"
+- high_priority_channel: "https://example.webhook.office.com/webhookb2/xxxx/aaa/bbb"
+- low_priority_channel: "https://example.webhook.office.com/webhookb2/xxxx/aaa/ccc"
 ```
 
 > __NOTE__: high_priority_channel and low_priority_channel are example handler or request path names.
@@ -240,10 +238,10 @@ curl localhost:2000/config
 
 [
   {
-    "high_priority_channel": "https://outlook.office.com/webhook/xxxx/aaa/bbb"
+    "high_priority_channel": "https://example.webhook.office.com/webhookb2/xxxx/aaa/bbb"
   },
   {
-    "low_priority_channel": "https://outlook.office.com/webhook/xxxx/aaa/ccc"
+    "low_priority_channel": "https://example.webhook.office.com/webhookb2/xxxx/aaa/ccc"
   }
 ]
 ```
@@ -287,7 +285,7 @@ When running as a docker container, mount the template file in the container and
 ```bash
 docker run -d -p 2000:2000 \
     --name="promteams" \
-    -e TEAMS_INCOMING_WEBHOOK_URL="https://outlook.office.com/webhook/xxx" \
+    -e TEAMS_INCOMING_WEBHOOK_URL="https://example.webhook.office.com/webhookb2/xxx" \
     -v /tmp/card.tmpl:/tmp/card.tmpl \
     -e TEMPLATE_FILE="/tmp/card.tmpl" \
     quay.io/prometheusmsteams/prometheus-msteams

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -69,16 +69,15 @@ func parseTeamsConfigFile(f string) (PromTeamsConfig, error) {
 	return tc, nil
 }
 
-// New Webhook URL announcement: https://admin.microsoft.com/AdminPortal/Home#/MessageCenter/:/messages/MC234048
-var validWebhookPattern = regexp.MustCompile(`^[a-z0-9]+\.webhook\.office\.com/webhookb2/[a-z0-9\-]+@[a-z0-9\-]+/IncomingWebhook/[a-z0-9]+/[a-z0-9\-]+$`)
-var legacyWebhookPrefix = "outlook.office.com/webhook/" // old format is only valid until 11. april '21
+// New Webhook URL format : https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/
+var validWebhookPattern = regexp.MustCompile(`^[a-z0-9]+\.webhook\.office\.com/webhookb2/[a-z0-9\-]+@[a-z0-9\-]+/IncomingWebhook/[a-z0-9]+/[a-z0-9\-]+(/[a-zA-Z0-9\-]+)?$`)
 
 func validateWebhook(u string) error {
 	path := strings.TrimPrefix(u, "https://")
 	if u == path {
 		return fmt.Errorf("the webhook_url must start with 'https://'. url: '%s'", u)
 	}
-	isValidTeamsHook := validWebhookPattern.MatchString(path) || strings.HasPrefix(path, legacyWebhookPrefix)
+	isValidTeamsHook := validWebhookPattern.MatchString(path)
 	if !isValidTeamsHook {
 		return fmt.Errorf("the webhook_url has an unexpected format '%s'", u)
 	}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -16,8 +16,8 @@ func Test_validateWebhook(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{name: "legacy hook", args: args{u: "https://outlook.office.com/webhook/1e21eb6d-60f4-432f-9428-82cf86ec55a3@b12d4011-2ea0-4377-a99b-35c565546afd/IncomingWebhook/091d20cd2a594db0b2d7ed2937d7bd6d/91f7b1cc-96d0-4612-bedd-8b820c869464"}, wantErr: false},
-		{name: "new webhook", args: args{u: "https://example.webhook.office.com/webhookb2/5c51ab94-86c0-4ba3-a66c-c2ad73acc531@e3ebcd52-aa57-25e8-a214-94fb325450f4/IncomingWebhook/9f226e3c36fb47249f14d4dab2d5b845/92bac26e-62c5-427f-ac91-e51a268f94ca"}, wantErr: false},
+		{name: "legacy hook", args: args{u: "https://example.webhook.office.com/webhookb2/1e21eb6d-60f4-432f-9428-82cf86ec55a3@b12d4011-2ea0-4377-a99b-35c565546afd/IncomingWebhook/091d20cd2a594db0b2d7ed2937d7bd6d/91f7b1cc-96d0-4612-bedd-8b820c869464"}, wantErr: false},
+		{name: "new webhook", args: args{u: "https://example.webhook.office.com/webhookb2/5c51ab94-86c0-4ba3-a66c-c2ad73acc531@e3ebcd52-aa57-25e8-a214-94fb325450f4/IncomingWebhook/9f226e3c36fb47249f14d4dab2d5b845/92bac26e-62c5-427f-ac91-e51a268f94ca/V2QaKKUiGE6BMqWd-DeObKqCFmiQE5WSekPuAwjhc6ads1"}, wantErr: false},
 		{name: "missing https", args: args{u: "outlook.office.com/webhook/xxxx/xxxx"}, wantErr: true},
 		{name: "only http", args: args{u: "http://outlook.office.com/webhook/xxxx/xxxx"}, wantErr: true},
 		{name: "https but invalid", args: args{u: "https://example.com"}, wantErr: true},
@@ -33,8 +33,8 @@ func Test_validateWebhook(t *testing.T) {
 }
 
 func Test_extractWebhookFromRequest(t *testing.T) {
-	oldStyleWebhook := "outlook.office.com/webhook/1e21eb6d-60f4-432f-9428-82cf86ec55a3@b12d4011-2ea0-4377-a99b-35c565546afd/IncomingWebhook/091d20cd2a594db0b2d7ed2937d7bd6d/91f7b1cc-96d0-4612-bedd-8b820c869464"
-	newStyleWebhook := "example.webhook.office.com/webhookb2/5c51ab94-86c0-4ba3-a66c-c2ad73acc531@e3ebcd52-aa57-25e8-a214-94fb325450f4/IncomingWebhook/9f226e3c36fb47249f14d4dab2d5b845/92bac26e-62c5-427f-ac91-e51a268f94ca"
+	oldStyleWebhook := "example.webhook.office.com/webhookb2/1e21eb6d-60f4-432f-9428-82cf86ec55a3@b12d4011-2ea0-4377-a99b-35c565546afd/IncomingWebhook/091d20cd2a594db0b2d7ed2937d7bd6d/91f7b1cc-96d0-4612-bedd-8b820c869464"
+	newStyleWebhook := "example.webhook.office.com/webhookb2/5c51ab94-86c0-4ba3-a66c-c2ad73acc531@e3ebcd52-aa57-25e8-a214-94fb325450f4/IncomingWebhook/9f226e3c36fb47249f14d4dab2d5b845/92bac26e-62c5-427f-ac91-e51a268f94ca/V2QaKKUiGE6BMqWd-DeObKqCFmiQE5WSekPuAwjhc6ads1"
 	tests := []struct {
 		name          string
 		request       *http.Request


### PR DESCRIPTION
Fixes #359

* Deprecated the old format (outlook.office.com)
* Updated the validating regex (`validate-webhook-url` flag) to support the current & new format
* Update README examples with the new pattern