### PR TITLE
Allow user to create or refferrence different service accounts

### DIFF
--- a/chart/prometheus-msteams/templates/_helpers.tpl
+++ b/chart/prometheus-msteams/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Return the appropriate apiVersion for deployment.
 {{- print "apps/v1beta2" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "app.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/prometheus-msteams/templates/deployment.yaml
+++ b/chart/prometheus-msteams/templates/deployment.yaml
@@ -28,10 +28,11 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
-      {{- end}}
+      {{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/chart/prometheus-msteams/templates/serviceaccount.yaml
+++ b/chart/prometheus-msteams/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.serviceAccountName" . }}
+  labels:
+    app: {{ template "app.name" . }}
+    release: {{ .Release.Name }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/prometheus-msteams/values.yaml
+++ b/chart/prometheus-msteams/values.yaml
@@ -28,12 +28,12 @@ service:
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: true
+  create: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: "prometheus-msteams"
+  name: ""
 
 nodeSelector: {}
 

--- a/chart/prometheus-msteams/values.yaml
+++ b/chart/prometheus-msteams/values.yaml
@@ -26,6 +26,15 @@ service:
   type: ClusterIP
   port: 2000
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "prometheus-msteams"
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
This PR implements the FEATURE #361 

User can now:

* create a service account and use it
* reference an existing service account
* us default service account


```yaml
# use default service account 
serviceAccount:
  create: false
  annotations: {}
  name: ""

# create and use a service account 
serviceAccount:
  create: true
  annotations: {}
  name: "some-sa-name"

# use (but not create) a different service account 
serviceAccount:
  create: false
  annotations: {}
  name: "existing-sa"
```
