### PR TITLE
(feat) Added PDB resource as an option, removed deprecations

### DIFF
--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.5.3"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
 home: https://github.com/prometheus-msteams/prometheus-msteams
-version: 1.3.5
+version: 1.3.6
 maintainers:
   - name: bzon
     url: https://github.com/bzon

--- a/chart/prometheus-msteams/templates/poddisruptionbudget.yaml
+++ b/chart/prometheus-msteams/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-i{{- if .Values.podDisruptionBudget.enabled }}
+{{- if .Values.podDisruptionBudget.enabled }}
 {{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}itVersion) }}
 apiVersion: policy/v1
 {{- else }}

--- a/chart/prometheus-msteams/templates/poddisruptionbudget.yaml
+++ b/chart/prometheus-msteams/templates/poddisruptionbudget.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}itVersion) }}
+{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "app.name" . }}quot; . }}
+  name: {{ template "app.name" . }}
   labels:
-    app: {{ template "app.name" . }}quot; . }}
+    app: {{ template "app.name" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -19,6 +19,6 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ template "app.name" . }}quot; . }}
+      app: {{ template "app.name" . }}
       release: {{ .Release.Name }}
 {{- end }}

--- a/chart/prometheus-msteams/templates/poddisruptionbudget.yaml
+++ b/chart/prometheus-msteams/templates/poddisruptionbudget.yaml
@@ -1,0 +1,24 @@
+i{{- if .Values.podDisruptionBudget.enabled }}
+{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}itVersion) }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "app.name" . }}quot; . }}
+  labels:
+    app: {{ template "app.name" . }}quot; . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- if and (.Values.podDisruptionBudget.maxUnavailable) (not .Values.podDisruptionBudget.minAvailable) }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "app.name" . }}quot; . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/chart/prometheus-msteams/values.yaml
+++ b/chart/prometheus-msteams/values.yaml
@@ -101,3 +101,9 @@ envFrom: {}
 
 # Whether to use the new Microsoft Workflow webhooks
 workflowWebhook: false
+
+# Allow PodDisruptionBudget to be configured
+podDisruptionBudget:
+  enabled: false
+  # maxUnavailable: 1
+  # minAvailable: 1

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -58,7 +57,7 @@ type ConnectorWithCustomTemplate struct {
 }
 
 func parseTeamsConfigFile(f string) (PromTeamsConfig, error) {
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		return PromTeamsConfig{}, err
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -38,7 +38,7 @@ func TestServer(t *testing.T) {
 	// Create a dummy Microsoft teams server.
 	teamsSrv := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			b, _ := ioutil.ReadAll(r.Body)
+			b, _ := io.ReadAll(r.Body)
 			logger.Log("request", string(b))
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte("1"))

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/prometheus-msteams/prometheus-msteams/pkg/card"
@@ -127,7 +127,7 @@ func (s simpleService) post(ctx context.Context, c interface{}, url string) (Pos
 
 	pr.Status = resp.StatusCode
 
-	rb, err := ioutil.ReadAll(resp.Body)
+	rb, err := io.ReadAll(resp.Body)
 	if err != nil {
 		err = fmt.Errorf("failed reading http response body: %w", err)
 		pr.Message = err.Error()

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -3,7 +3,6 @@ package testutils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ import (
 
 // ParseWebhookJSONFromFile is a helper for parsing webhook data from JSON files.
 func ParseWebhookJSONFromFile(f string) (webhook.Message, error) {
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		return webhook.Message{}, err
 	}
@@ -38,15 +37,15 @@ func CompareToGoldenFile(t *testing.T, v interface{}, file string, update bool) 
 		_ = os.MkdirAll(dir, 0755)
 	}
 	if _, err := os.Stat(gp); os.IsNotExist(err) {
-		_ = ioutil.WriteFile(gp, []byte{}, 0600)
+		_ = os.WriteFile(gp, []byte{}, 0600)
 	}
 	if update {
 		t.Log("updating golden file")
-		if err := ioutil.WriteFile(gp, gotBytes, 0600); err != nil {
+		if err := os.WriteFile(gp, gotBytes, 0600); err != nil {
 			t.Fatalf("failed to update golden file: %s", err)
 		}
 	}
-	want, err := ioutil.ReadFile(gp)
+	want, err := os.ReadFile(gp)
 	if err != nil {
 		t.Fatalf("failed reading the golden file: %s", err)
 	}

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -3,7 +3,7 @@ package transport
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -105,7 +105,7 @@ func handleRoute(c echo.Context, s service.Service, logger log.Logger) error {
 	ctx, span := trace.StartSpan(c.Request().Context(), "alertmanager-handler")
 	defer span.End()
 
-	b, err := ioutil.ReadAll(c.Request().Body)
+	b, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		logger.Log("err", err)
 		span.SetStatus(trace.Status{Code: 500, Message: err.Error()})


### PR DESCRIPTION
- Added the possibility to configure a PodDisruptionBudget in Helm chart proprietary
- Remove `ioutil` deprecated package, and replace it with `os` and `io`