### PR TITLE
fix(workflow): allow full Adaptive Card schema in custom templates

### DIFF
--- a/pkg/card/converterWorkflow.go
+++ b/pkg/card/converterWorkflow.go
@@ -20,13 +20,13 @@ type MsTeams struct {
 
 // Content represents the content of an adaptive card for Workflow connector cards.
 type Content struct {
-	Schema          string          `json:"$schema"`
-	Type            string          `json:"type"`
-	Version         string          `json:"version"`
+	Schema          string                   `json:"$schema"`
+	Type            string                   `json:"type"`
+	Version         string                   `json:"version"`
 	Body            []map[string]interface{} `json:"body"`
-	MsTeams         MsTeams         `json:"msteams"`
-	Actions         []Action        `json:"actions,omitempty"`
-	BackgroundImage BackgroundImage `json:"backgroundImage,omitempty"`
+	MsTeams         MsTeams                  `json:"msteams"`
+	Actions         []Action                 `json:"actions,omitempty"`
+	BackgroundImage BackgroundImage          `json:"backgroundImage,omitempty"`
 }
 
 // AdaptiveCardItem represents an adaptive card item within a Workflow connector card attachment.

--- a/pkg/card/converterWorkflow.go
+++ b/pkg/card/converterWorkflow.go
@@ -7,25 +7,6 @@ import (
 	"github.com/prometheus/alertmanager/notify/webhook"
 )
 
-// FactSectionWorkflow represents a name/value pair fact for Workflow connector cards.
-type FactSectionWorkflow struct {
-	Title string `json:"title"`
-	Value string `json:"value"`
-}
-
-// Body represents a body element in an adaptive card for Workflow connector cards.
-type Body struct {
-	Type   string                `json:"type"`
-	Text   string                `json:"text"`
-	Weight string                `json:"weight,omitempty"`
-	Size   string                `json:"size,omitempty"`
-	Wrap   bool                  `json:"wrap,omitempty"`
-	Style  string                `json:"style,omitempty"`
-	Color  string                `json:"color,omitempty"`
-	Bleed  bool                  `json:"bleed,omitempty"`
-	Facts  []FactSectionWorkflow `json:"facts,omitempty"`
-}
-
 // BackgroundImage represents the background image configuration for an adaptive card.
 type BackgroundImage struct {
 	URL      string `json:"url"`
@@ -42,7 +23,7 @@ type Content struct {
 	Schema          string          `json:"$schema"`
 	Type            string          `json:"type"`
 	Version         string          `json:"version"`
-	Body            []Body          `json:"body"`
+	Body            []map[string]interface{} `json:"body"`
 	MsTeams         MsTeams         `json:"msteams"`
 	Actions         []Action        `json:"actions,omitempty"`
 	BackgroundImage BackgroundImage `json:"backgroundImage,omitempty"`

--- a/pkg/card/templated_card.go
+++ b/pkg/card/templated_card.go
@@ -19,7 +19,6 @@ const messageCardType = "MessageCard"
 
 const workflowCardType = "message"
 
-
 // templatedCard implements Converter using Alert manager templating.
 type templatedCard struct {
 	template *template.Template

--- a/pkg/card/templated_card.go
+++ b/pkg/card/templated_card.go
@@ -17,6 +17,9 @@ import (
 
 const messageCardType = "MessageCard"
 
+const workflowCardType = "message"
+
+
 // templatedCard implements Converter using Alert manager templating.
 type templatedCard struct {
 	template *template.Template
@@ -64,7 +67,7 @@ func (m *templatedCard) ConvertWorkflow(ctx context.Context, promAlert webhook.M
 		return WorkflowConnectorCard{}, err
 	}
 
-	if card.Type != "message" {
+	if card.Type != workflowCardType {
 		return WorkflowConnectorCard{}, errors.New("only message type is supported")
 	}
 

--- a/pkg/card/templated_card_test.go
+++ b/pkg/card/templated_card_test.go
@@ -24,6 +24,7 @@ const (
 	testLabelSummary    = "summary"
 	testLabelMonitor    = "monitor"
 	testSeverityWarning = "warning"
+	testTextBlockType   = "TextBlock"
 )
 
 func Test_templatedCard_Convert(t *testing.T) {
@@ -191,7 +192,7 @@ func Test_templatedCard_ConvertWorkflow(t *testing.T) {
 						types = append(types, typ)
 					}
 				}
-				wantTypes := []string{"TextBlock", "TextBlock", "TextBlock", "FactSet"}
+				wantTypes := []string{testTextBlockType, testTextBlockType, testTextBlockType, "FactSet"}
 				if diff := cmp.Diff(wantTypes, types); diff != "" {
 					t.Fatalf("body element types mismatch (-want +got):\n%s", diff)
 				}

--- a/pkg/card/templated_card_test.go
+++ b/pkg/card/templated_card_test.go
@@ -175,8 +175,8 @@ func Test_templatedCard_ConvertWorkflow(t *testing.T) {
 			templateFile:  "../../default-message-workflow-card.tmpl",
 			checkFn: func(t *testing.T, got WorkflowConnectorCard) {
 				t.Helper()
-				if got.Type != "message" {
-					t.Fatalf("want type %q, got %q", "message", got.Type)
+				if got.Type != workflowCardType {
+					t.Fatalf("want type %q, got %q", workflowCardType, got.Type)
 				}
 				if len(got.Attachments) != 1 {
 					t.Fatalf("want 1 attachment, got %d", len(got.Attachments))
@@ -213,8 +213,8 @@ func Test_templatedCard_ConvertWorkflow(t *testing.T) {
 			templateFile:  "./testdata/workflow_columnset.tmpl",
 			checkFn: func(t *testing.T, got WorkflowConnectorCard) {
 				t.Helper()
-				if got.Type != "message" {
-					t.Fatalf("want type %q, got %q", "message", got.Type)
+				if got.Type != workflowCardType {
+					t.Fatalf("want type %q, got %q", workflowCardType, got.Type)
 				}
 				if len(got.Attachments) != 1 {
 					t.Fatalf("want 1 attachment, got %d", len(got.Attachments))

--- a/pkg/card/templated_card_test.go
+++ b/pkg/card/templated_card_test.go
@@ -156,3 +156,123 @@ func Test_templatedCard_Convert(t *testing.T) {
 		})
 	}
 }
+
+func Test_templatedCard_ConvertWorkflow(t *testing.T) {
+	tests := []struct {
+		name          string
+		promAlertFile string
+		templateFile  string
+		wantErr       bool
+		// checkFn allows each case to assert what matters without
+		// hard-coding the full card structure.
+		checkFn func(t *testing.T, got WorkflowConnectorCard)
+	}{
+		{
+			// The default workflow template uses TextBlock and FactSet elements.
+			// Verify that both element types survive the unmarshal/marshal round-trip.
+			name:          "default template preserves TextBlock and FactSet",
+			promAlertFile: "./testdata/prom_post_request.json",
+			templateFile:  "../../default-message-workflow-card.tmpl",
+			checkFn: func(t *testing.T, got WorkflowConnectorCard) {
+				t.Helper()
+				if got.Type != "message" {
+					t.Fatalf("want type %q, got %q", "message", got.Type)
+				}
+				if len(got.Attachments) != 1 {
+					t.Fatalf("want 1 attachment, got %d", len(got.Attachments))
+				}
+				body := got.Attachments[0].Content.Body
+				if len(body) == 0 {
+					t.Fatal("body must not be empty")
+				}
+				var types []string
+				for _, elem := range body {
+					if typ, ok := elem["type"].(string); ok {
+						types = append(types, typ)
+					}
+				}
+				wantTypes := []string{"TextBlock", "TextBlock", "TextBlock", "FactSet"}
+				if diff := cmp.Diff(wantTypes, types); diff != "" {
+					t.Fatalf("body element types mismatch (-want +got):\n%s", diff)
+				}
+				// FactSet must carry its facts slice
+				factSet := body[len(body)-1]
+				facts, ok := factSet["facts"].([]interface{})
+				if !ok || len(facts) == 0 {
+					t.Fatalf("FactSet element missing facts, got: %v", factSet)
+				}
+			},
+		},
+		{
+			// A custom template using ColumnSet — an element type not present in
+			// the original []Body struct.  Verifies that the looser
+			// []map[string]interface{} type preserves all fields (columns, items,
+			// style) instead of silently dropping them.
+			name:          "custom template preserves ColumnSet",
+			promAlertFile: "./testdata/prom_post_request.json",
+			templateFile:  "./testdata/workflow_columnset.tmpl",
+			checkFn: func(t *testing.T, got WorkflowConnectorCard) {
+				t.Helper()
+				if got.Type != "message" {
+					t.Fatalf("want type %q, got %q", "message", got.Type)
+				}
+				if len(got.Attachments) != 1 {
+					t.Fatalf("want 1 attachment, got %d", len(got.Attachments))
+				}
+				body := got.Attachments[0].Content.Body
+				if len(body) != 1 {
+					t.Fatalf("want 1 body element, got %d", len(body))
+				}
+				elem := body[0]
+				if typ, _ := elem["type"].(string); typ != "ColumnSet" {
+					t.Fatalf("want body element type %q, got %q", "ColumnSet", typ)
+				}
+				if style, _ := elem["style"].(string); style != "attention" {
+					t.Fatalf("want ColumnSet style %q, got %q", "attention", style)
+				}
+				columns, ok := elem["columns"].([]interface{})
+				if !ok || len(columns) == 0 {
+					t.Fatalf("ColumnSet missing columns, got: %v", elem)
+				}
+				col, ok := columns[0].(map[string]interface{})
+				if !ok {
+					t.Fatalf("column is not an object, got: %T", columns[0])
+				}
+				if colType, _ := col["type"].(string); colType != "Column" {
+					t.Fatalf("want column type %q, got %q", "Column", colType)
+				}
+				items, ok := col["items"].([]interface{})
+				if !ok || len(items) == 0 {
+					t.Fatalf("Column missing items, got: %v", col)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := ParseTemplateFile(tt.templateFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			a, err := testutils.ParseWebhookJSONFromFile(tt.promAlertFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			m := NewTemplatedCardCreator(tmpl, false)
+
+			got, err := m.ConvertWorkflow(context.Background(), a)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("templatedCard.ConvertWorkflow() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.checkFn != nil {
+				tt.checkFn(t, got)
+			}
+		})
+	}
+}

--- a/pkg/card/testdata/workflow_columnset.tmpl
+++ b/pkg/card/testdata/workflow_columnset.tmpl
@@ -1,0 +1,24 @@
+{{ define "teams.card" }}
+{
+  "type": "message",
+  "attachments": [{
+    "contentType": "application/vnd.microsoft.card.adaptive",
+    "contentUrl": null,
+    "content": {
+      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+      "type": "AdaptiveCard",
+      "version": "1.2",
+      "msteams": { "width": "Full" },
+      "body": [{
+        "type": "ColumnSet",
+        "style": "attention",
+        "columns": [{
+          "type": "Column",
+          "width": "stretch",
+          "items": [{ "type": "TextBlock", "text": "test" }]
+        }]
+      }]
+    }
+  }]
+}
+{{ end }}


### PR DESCRIPTION
## Problem

`workflowWebhook: true` mode deserialises the rendered template output into a strict Go struct:

```go
type Body struct {
    Type   string                `json:"type"`
    Text   string                `json:"text"`
    Weight string                `json:"weight,omitempty"`
    Size   string                `json:"size,omitempty"`
    Wrap   bool                  `json:"wrap,omitempty"`
    Style  string                `json:"style,omitempty"`
    Color  string                `json:"color,omitempty"`
    Bleed  bool                  `json:"bleed,omitempty"`
    Facts  []FactSectionWorkflow `json:"facts,omitempty"`
}
```

Because `json.Unmarshal` into a strict struct silently drops unknown fields, any Adaptive Card element not listed in `Body` — `ColumnSet`, `Column`, `ActionSet`, `Container`, `ImageSet`, `Image`, `RichTextBlock`, etc. — is **stripped before the payload reaches Teams**.

`customCardTemplate` is therefore limited to `TextBlock` + `FactSet` only, making rich card layouts impossible despite Teams accepting the full Adaptive Card schema without restriction (confirmed: HTTP 202 with `ColumnSet` body via direct curl).

## Fix

Replace `Body []Body` with `[]map[string]interface{}` in the `Content` struct and remove the now-unnecessary `Body` and `FactSectionWorkflow` types entirely.

This lets `json.Unmarshal` preserve every field from the template output without any schema enforcement at the Go layer — Teams enforces its own schema anyway.

This matches the approach already used for `Action` in `converter.go` (`type Action map[string]interface{}`).

## Changes

- **`pkg/card/converterWorkflow.go`**: remove `FactSectionWorkflow` and `Body` structs; change `Content.Body` from `[]Body` to `[]map[string]interface{}`
- **`pkg/card/testdata/workflow_columnset.tmpl`**: new test fixture with a `ColumnSet` body element
- **`pkg/card/templated_card_test.go`**: add `Test_templatedCard_ConvertWorkflow` with two cases:
  - default template: `TextBlock` + `FactSet` round-trip is preserved (no regression)
  - custom template: `ColumnSet` with `columns`/`items`/`style` is preserved (not stripped)

## Impact

This Allows the following Cards:
https://imgur.com/a/FtpcU7l

| Area | Impact |
|---|---|
| Default template (`default-message-workflow-card.tmpl`) | No change — `TextBlock`/`FactSet` marshal identically through the looser type |
| Existing `customCardTemplate` users | No breaking change — previously working templates continue to work |
| Actions max-5 warning in logging middleware | Unaffected — `len(attachment.Content.Actions)` is still a slice |
| Binary size / performance | Negligible — `map[string]interface{}` vs struct unmarshal is equivalent |

Fixes #202

---

## On the choice of `[]map[string]interface{}` vs `[]json.RawMessage`

A reviewer might ask why not use `[]json.RawMessage` to get both type safety and full schema preservation. The short answer is: it would work, but it buys nothing in this codebase.

`json.RawMessage` makes sense when you need to defer decoding and inspect individual fields later in Go code. The body element flow here is purely:

```
template string → json.Unmarshal → []body elements → json.Marshal → POST
```

No Go code ever reads a field from a body element — the structs are only ever a pass-through between unmarshal and marshal. Given that, `[]json.RawMessage` and `[]map[string]interface{}` are equivalent in behaviour, with one practical difference: `json.RawMessage` preserves the original byte sequence exactly (key order, whitespace), while `map[string]interface{}` re-serialises through Go's map iteration (sorted keys, no extra whitespace). Neither matters for Teams.

The `[]map[string]interface{}` approach was chosen because it is consistent with `Action`, which is already `type Action map[string]interface{}` in `converter.go` for exactly the same reason — MS Teams actions also have multiple subtypes that cannot be unified into a single struct without losing fields.

If a future change needs to inspect or validate body elements in Go (e.g. to warn on >5 actions inside an `ActionSet`), the right move at that point would be a type-switch on the `"type"` key, which works identically with both approaches.