### PR TITLE
chore: bump Go version to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,4 +95,4 @@ require (
 	k8s.io/apimachinery v0.18.8 // indirect
 )
 
-go 1.23
+go 1.25.0


### PR DESCRIPTION
Bump Go version from 1.23 to 1.25.0 and run go mod tidy to resolve transitive dependencies cleanly.

This unblocks Dependabot PRs (e.g. #416) that require Go 1.25.0.