### PR TITLE
feat: add linux/arm64 support (#427)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,6 +85,7 @@ jobs:
             default-message-card.tmpl
             bin/prometheus-msteams-darwin-amd64
             bin/prometheus-msteams-linux-amd64
+            bin/prometheus-msteams-linux-arm64
             bin/prometheus-msteams-windows-amd64.exe
             bin/shasum256.txt
 
@@ -94,5 +95,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
 
 COPY ./default-message-card.tmpl /default-message-card.tmpl
 COPY ./default-message-workflow-card.tmpl /default-message-workflow-card.tmpl
-COPY bin/prometheus-msteams-linux-amd64 /promteams
+ARG TARGETARCH=amd64
+COPY bin/prometheus-msteams-linux-${TARGETARCH} /promteams
 
 ENTRYPOINT ["/promteams"]
+

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ DOCKER_QUAY_USER=prometheusmsteams+ci
 DOCKER_HUB_REPO=prometheusmsteams/prometheus-msteams
 
 # Build the project
-all: clean dep create_bin_dir linux darwin windows
-	cd $(BINDIR) && shasum -a 256 ** > shasum256.txt
+all: clean dep create_bin_dir linux-amd64 linux-arm64 darwin windows
+	cd $(BINDIR) && shasum -a 256 * > shasum256.txt
 
 create_bin_dir:
 	rm -fr $(BINDIR)
@@ -41,6 +41,12 @@ github_release:
 linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) $(GO) build $(LDFLAGS) -o $(BINDIR)/$(BINARY)-linux-$(GOARCH) ./cmd/server
 
+linux-amd64:
+	$(MAKE) linux GOARCH=amd64
+
+linux-arm64:
+	$(MAKE) linux GOARCH=arm64
+
 darwin:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=$(GOARCH) $(GO) build $(LDFLAGS) -o $(BINDIR)/$(BINARY)-darwin-$(GOARCH) ./cmd/server
 
@@ -48,8 +54,9 @@ windows:
 	CGO_ENABLED=0 GOOS=windows GOARCH=$(GOARCH) $(GO) build $(LDFLAGS) -o $(BINDIR)/$(BINARY)-windows-$(GOARCH).exe ./cmd/server
 
 docker:
-	docker build -t $(DOCKER_HUB_REPO):$(VERSION) .
+	docker build --build-arg TARGETARCH=$(GOARCH) -t $(DOCKER_HUB_REPO):$(VERSION) .
 	docker tag $(DOCKER_HUB_REPO):$(VERSION) $(DOCKER_QUAY_REPO):$(VERSION)
+
 
 docker-hub-login:
 	echo ${DOCKER_PASSWORD} | docker login --password-stdin -u ${DOCKER_USER}


### PR DESCRIPTION
### Description

This Pull Request adds support for the `linux/arm64` architecture. It compiles and publishes the `linux-arm64` binary on release tags, and updates the Docker release workflow to build and push a multi-architecture (`linux/amd64` and `linux/arm64`) image.

Key changes:
- **Dockerfile:** Declared the `TARGETARCH` argument (defaults to `amd64`) and used it to copy the architecture-specific binary.
- **Makefile:** Added explicit targets for `linux-amd64` and `linux-arm64`, updated `all` to compile both, and updated the local `docker` target to pass the active `GOARCH` as `TARGETARCH` build arg.
- **CI/CD Workflow:** Added `bin/prometheus-msteams-linux-arm64` to GitHub Release artifacts and enabled multi-platform builds (`linux/amd64,linux/arm64`) on the Docker push step in `.github/workflows/release.yaml`.

Closes #427

### Checklist
- [x] Code compiles correctly (verified Go compilation for all targets inside a dedicated toolbox)
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
